### PR TITLE
Add initial .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.tfstate
+*.tfstate.backup
+.terraform
+.terraform.lock.hcl


### PR DESCRIPTION
Ignore all `.terraform` directories, Terraform state and backup state and Terraform dependency Lock File (most of the time Terraform providers are locally (re)built via pkgsrc and storing checksums for each rebuild is not nice).
