### PR TITLE
Spin up Moto server

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -10,6 +10,13 @@ jobs:
   terraform:
     name: Check and validate Terraform live modules
     runs-on: 'ubuntu-latest'
+
+    services:
+      moto:
+        image: motoserver/moto:4.0.9
+        ports:
+          - 4566:5000
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Run Moto in Server mode in order to be used to mock up AWS API so that infrastructure can be created and destroyed.

Map to port 4566 that is the most common one used by LocalStack.

(For the moment Moto is probably good enough and LocalStack is not happy with recent Terraform AWS Provider due https://github.com/localstack/localstack/issues/7046 so we would need to pin Terraform AWS provider to an older version to possibly workaround that if/when we would like to switch to LocalStack.)
