### PR TITLE
Switch to `s3_use_path_style'

### DIFF
--- a/terraform/vpc-simple/main.tf
+++ b/terraform/vpc-simple/main.tf
@@ -13,7 +13,7 @@ provider "aws" {
   access_key                  = "test"
   secret_key                  = "test"
   region                      = "us-east-1"
-  s3_force_path_style         = false
+  s3_use_path_style           = false
   skip_credentials_validation = true
   skip_metadata_api_check     = true
   skip_requesting_account_id  = true


### PR DESCRIPTION
Address deprecation warning by switching from `s3_force_path_style` to `s3_use_path_style` argument for the AWS provider.

NFCI.
