### PR TITLE
Add `eks-attach-policy-to-nodes` live module

### DIFF
--- a/terraform/eks-attach-policy-to-nodes/main.tf
+++ b/terraform/eks-attach-policy-to-nodes/main.tf
@@ -1,0 +1,106 @@
+terraform {
+  required_version = "~> 1.3"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      # XXX: 4.40.0 triggers `describe_security_group_rules' action calls not
+      # XXX: yet supported by moto-4.0.9.
+      version = ">= 4.0, < 4.40.0"
+    }
+  }
+}
+
+provider "aws" {
+  access_key                  = "test"
+  secret_key                  = "test"
+  region                      = "us-east-1"
+  s3_use_path_style           = false
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    apigateway     = "http://localhost:4566"
+    apigatewayv2   = "http://localhost:4566"
+    cloudformation = "http://localhost:4566"
+    cloudwatch     = "http://localhost:4566"
+    dynamodb       = "http://localhost:4566"
+    ec2            = "http://localhost:4566"
+    eks            = "http://localhost:4566"
+    es             = "http://localhost:4566"
+    elasticache    = "http://localhost:4566"
+    firehose       = "http://localhost:4566"
+    iam            = "http://localhost:4566"
+    kinesis        = "http://localhost:4566"
+    lambda         = "http://localhost:4566"
+    logs           = "http://localhost:4566"
+    rds            = "http://localhost:4566"
+    redshift       = "http://localhost:4566"
+    route53        = "http://localhost:4566"
+    s3             = "http://s3.localhost.localstack.cloud:4566"
+    secretsmanager = "http://localhost:4566"
+    ses            = "http://localhost:4566"
+    sns            = "http://localhost:4566"
+    sqs            = "http://localhost:4566"
+    ssm            = "http://localhost:4566"
+    stepfunctions  = "http://localhost:4566"
+    sts            = "http://localhost:4566"
+  }
+}
+
+locals {
+  cluster_name    = "eks-attach-policy-to-nodes"
+  cluster_version = "1.23"
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 18.0"
+
+  cluster_name    = local.cluster_name
+  cluster_version = local.cluster_version
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
+
+  name = "vpc-simple"
+  cidr = "10.0.0.0/16"
+
+  azs             = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                      = 1
+  }
+  public_subnets = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                      = 1
+  }
+
+  enable_dns_hostnames = true
+  enable_nat_gateway   = true
+
+  tags = {
+    Project   = "eks-attach-policy-to-nodes"
+    Terraform = "true"
+  }
+}
+
+#
+# XXX: This is not a nice way to add IAM policy! IRSA (IAM Role for Service
+# XXX: Account) should be used instead so that only the pods using the proper
+# XXX: Kubernetes service account can do such actions.
+#
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent" {
+  # FIXME: This should be the node group IAM role name, not the cluster role
+  # FIXME: name! But we need to create nodes in order to be able to do that!
+  role       = module.eks.cluster_iam_role_name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}


### PR DESCRIPTION
Add a live module to demonstrate an IAM policy that is attached directly to cluster role while IRSA should be used instead.

Intended to write policy against such usage pattern!
