### PR TITLE
Merge apply and destroy targets

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -36,9 +36,6 @@ jobs:
       - name: Generating Terraform live modules plans
         run: |
           make plan
-      - name: Applying Terraform live modules plans
+      - name: Applying and destroying Terraform live modules plans
         run: |
-          make apply
-      - name: Destroying Terraform live modules
-        run: |
-          make destroy
+          make apply-and-destroy

--- a/Makefile
+++ b/Makefile
@@ -42,22 +42,14 @@ plan: validate
 			$(TERRAFORM) -chdir="$${dirname}" plan; \
 		done
 
-apply: validate
-	@echo "Applying Terraform live modules plans"
+apply-and-destroy: validate
+	@echo "Applying and destroying Terraform live modules plans"
 	@set -e; \
 	find . -type f -not -path '*/.*' -name 'main.tf' | \
 		while IFS= read file; do \
 			dirname=$$(dirname $$file); \
 			echo "Applying plan for $${dirname}"; \
 			$(TERRAFORM) -chdir="$${dirname}" apply -auto-approve; \
-		done
-
-destroy:
-	@echo "Destroying Terraform live modules"
-	@set -e; \
-	find . -type f -not -path '*/.*' -name 'main.tf' | \
-		while IFS= read file; do \
-			dirname=$$(dirname $$file); \
 			echo "Destroying for $${dirname}"; \
 			$(TERRAFORM) -chdir="$${dirname}" apply -destroy \
 				-auto-approve; \


### PR DESCRIPTION
Moto by default use a single AWS account and creating all the live modules is going to conflict.

Merge the apply and destroy target so that each live module gets first created and then destroyed so that there should be no pending resources after each run.
