### PR TITLE
Prohibit >=4.40.0 aws provider

### DIFF
--- a/terraform/eks-simple/main.tf
+++ b/terraform/eks-simple/main.tf
@@ -3,8 +3,10 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~> 4.0"
+      source = "hashicorp/aws"
+      # XXX: 4.40.0 triggers `describe_security_group_rules' action calls not
+      # XXX: yet supported by moto-4.0.9.
+      version = ">= 4.0, < 4.40.0"
     }
   }
 }

--- a/terraform/vpc-simple/main.tf
+++ b/terraform/vpc-simple/main.tf
@@ -3,8 +3,10 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~> 4.0"
+      source = "hashicorp/aws"
+      # XXX: 4.40.0 triggers `describe_security_group_rules' action calls not
+      # XXX: yet supported by moto-4.0.9.
+      version = ">= 4.0, < 4.40.0"
     }
   }
 }


### PR DESCRIPTION
New aws provider triggers `describe_security_group_rules` that are not yet supported by Moto 4.0.9.

Should fix CI/CD pipeline that get stuck for 1 hours and 50 minutes and then failed due probably some timeout that were hit.
