### PR TITLE
Update to Moto 4.1.2

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -13,7 +13,7 @@ jobs:
 
     services:
       moto:
-        image: motoserver/moto:4.0.11
+        image: motoserver/moto:4.1.2
         ports:
           - 4566:5000
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Moto can be started in server-mode using
 [Docker](https://www.docker.com/), e.g.:
 
 ```
-$ docker run --detach --publish 4566:5000 --rm motoserver/moto:4.0.11
+$ docker run --detach --publish 4566:5000 --rm motoserver/moto:4.1.2
 c48475b85c7708f218486e25bc8658281ec1ff2e0a01c0729764d71f3fdb2463
 ```
 

--- a/terraform/eks-attach-policy-to-nodes/main.tf
+++ b/terraform/eks-attach-policy-to-nodes/main.tf
@@ -3,10 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # XXX: 4.40.0 triggers `describe_security_group_rules' action calls not
-      # XXX: yet supported by moto-4.0.9.
-      version = ">= 4.0, < 4.40.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/terraform/eks-simple/main.tf
+++ b/terraform/eks-simple/main.tf
@@ -3,10 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # XXX: 4.40.0 triggers `describe_security_group_rules' action calls not
-      # XXX: yet supported by moto-4.0.9.
-      version = ">= 4.0, < 4.40.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }

--- a/terraform/vpc-simple/main.tf
+++ b/terraform/vpc-simple/main.tf
@@ -3,10 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      # XXX: 4.40.0 triggers `describe_security_group_rules' action calls not
-      # XXX: yet supported by moto-4.0.9.
-      version = ">= 4.0, < 4.40.0"
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
     }
   }
 }


### PR DESCRIPTION
This PR updates to moto 4.1.2 and relax aws provider version requirements.
