### PR TITLE
Switch to eu-central-1 everywhere

### DIFF
--- a/terraform/eks-attach-policy-to-nodes/main.tf
+++ b/terraform/eks-attach-policy-to-nodes/main.tf
@@ -71,7 +71,7 @@ module "vpc" {
   name = "vpc-simple"
   cidr = "10.0.0.0/16"
 
-  azs             = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  azs             = ["eu-central-1a", "eu-central-1b", "eu-central-1c"]
   private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   private_subnet_tags = {
     "kubernetes.io/cluster/${local.cluster_name}" = "shared"

--- a/terraform/eks-simple/main.tf
+++ b/terraform/eks-simple/main.tf
@@ -71,7 +71,7 @@ module "vpc" {
   name = "vpc-simple"
   cidr = "10.0.0.0/16"
 
-  azs             = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  azs             = ["eu-central-1a", "eu-central-1b", "eu-central-1c"]
   private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   private_subnet_tags = {
     "kubernetes.io/cluster/${local.cluster_name}" = "shared"

--- a/terraform/vpc-simple/main.tf
+++ b/terraform/vpc-simple/main.tf
@@ -55,7 +55,7 @@ module "vpc" {
   name = "vpc-simple"
   cidr = "10.0.0.0/16"
 
-  azs             = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  azs             = ["eu-central-1a", "eu-central-1b", "eu-central-1c"]
   private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 


### PR DESCRIPTION
AZs of subnets were accidentally missed in commit a8eeb5f61aea23c5289ec9e4b782c4cddc324239.
