### PR TITLE
Add a self-managed node group and properly attach IAM policy to node group IAM role

### DIFF
--- a/terraform/eks-attach-policy-to-nodes/main.tf
+++ b/terraform/eks-attach-policy-to-nodes/main.tf
@@ -109,8 +109,6 @@ module "vpc" {
 # XXX: Kubernetes service account can do such actions.
 #
 resource "aws_iam_role_policy_attachment" "cloudwatch_agent" {
-  # FIXME: This should be the node group IAM role name, not the cluster role
-  # FIXME: name! But we need to create nodes in order to be able to do that!
-  role       = module.eks.cluster_iam_role_name
+  role       = module.eks.self_managed_node_groups["eks_attach_policy_to_nodes"].iam_role_name
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
 }

--- a/terraform/eks-attach-policy-to-nodes/main.tf
+++ b/terraform/eks-attach-policy-to-nodes/main.tf
@@ -60,6 +60,17 @@ module "eks" {
   cluster_name    = local.cluster_name
   cluster_version = local.cluster_version
 
+  self_managed_node_groups = {
+    eks_attach_policy_to_nodes = {
+      instance_type = "t3.xlarge"
+
+      min_size     = 6
+      max_size     = 6
+      desired_size = 6
+    }
+  }
+
+
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 }

--- a/terraform/eks-simple/main.tf
+++ b/terraform/eks-simple/main.tf
@@ -60,6 +60,16 @@ module "eks" {
   cluster_name    = local.cluster_name
   cluster_version = local.cluster_version
 
+  self_managed_node_groups = {
+    simple_eks = {
+      instance_type = "t3.xlarge"
+
+      min_size     = 6
+      max_size     = 6
+      desired_size = 6
+    }
+  }
+
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
 }


### PR DESCRIPTION
Add a node group with 6 nodes so that EKS examples are actually much more real now (a cluster without any worker nodes is not very useful usually!).

This also address the `FIXME` comment of `eks-attach-policy-to-nodes` by attaching the custom IAM policy to the node group IAM role.