### PR TITLE
Update EKS cluster to 1.24.x

### DIFF
--- a/terraform/eks-attach-policy-to-nodes/main.tf
+++ b/terraform/eks-attach-policy-to-nodes/main.tf
@@ -50,7 +50,7 @@ provider "aws" {
 
 locals {
   cluster_name    = "eks-attach-policy-to-nodes"
-  cluster_version = "1.23"
+  cluster_version = "1.24"
 }
 
 module "eks" {

--- a/terraform/eks-simple/main.tf
+++ b/terraform/eks-simple/main.tf
@@ -50,7 +50,7 @@ provider "aws" {
 
 locals {
   cluster_name    = "eks-simple"
-  cluster_version = "1.23"
+  cluster_version = "1.24"
 }
 
 module "eks" {


### PR DESCRIPTION
1.24 is the latest Amazon Kubernet supported version, update to it.
