### PR TITLE
Add mdformat GitHub Actions workflow

### DIFF
--- a/.github/workflows/mdformat.yaml
+++ b/.github/workflows/mdformat.yaml
@@ -1,0 +1,22 @@
+name: Check Markdown formatting via mdformat
+
+'on':
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  mdformat:
+    name: Check Markdown formatting via mdformat
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install mdformat
+        run: |
+          pip install mdformat
+      - name: Check Markdown formatting via mdformat
+        run: |
+          mdformat --check .

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Playground for master thesis containing code, documentation and examples to
 explore policy as code.
 
-
 ## Terraform
 
 In `terraform` directory there are several
@@ -25,8 +24,9 @@ This starts the container and print the container ID
 (`c48475b85c7708f218486e25bc8658281ec1ff2e0a01c0729764d71f3fdb2463`) to
 the standard output.
 
-Once Moto is running `terraform plan`, `terraform apply` and `terraform
-destroy` can be performed on the various Terraform live modules.
+Once Moto is running `terraform plan`, `terraform apply` and
+`terraform destroy` can be performed on the various Terraform live
+modules.
 
 A `Makefile` is provided to ease CI (continuous integration) checking
 and linting Terraform code and recursively create and destroy
@@ -42,7 +42,6 @@ container ID is
 ```
 $ docker stop c48475b85c7708f218486e25bc8658281ec1ff2e0a01c0729764d71f3fdb2463
 ```
-
 
 **WARNING**: all code/documentation/examples/etc. here will be probably
 in an eternal POC/WIP state. Reader beware!


### PR DESCRIPTION
Recursively check Markdown formatting via [mdformat](https://github.com/executablebooks/mdformat).

Unlike other possible linter mdformat has the advantage that can also format the Markdown file too without any manual edit (possible adjustments can be actually needed though for wrapping!).
