### PR TITLE
Switch to OpenTofu

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -25,9 +25,9 @@ jobs:
             sleep 2
           done
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: opentofu/setup-opentofu@v1
         with:
-          terraform_version: 1.3.x
+          tofu_version: 1.8.x
       - name: Setup tflint
         uses: terraform-linters/setup-tflint@v4
       - name: Checking Terraform formatting style

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .POSIX:
 
-TERRAFORM = terraform
+TERRAFORM = tofu
 TFLINT = tflint
 
 all:


### PR DESCRIPTION
This PR adjust Makefile and GitHub Actions workflows in order to start using OpenTofu instead of Terraform due nicer license.
