### PR TITLE
Check "managed" and "data" resources and clarify comments regarding the resources rule

### DIFF
--- a/rego/lib/tfstate/resources.rego
+++ b/rego/lib/tfstate/resources.rego
@@ -17,6 +17,11 @@ import input as tfstate
 # METADATA
 # description: |
 #  Walk the Terraform state and flatten all Terraform resources.
+#
+#  Please note that the Terraform resources in the state can be Terraform
+#  `resource` or `data` based on their `kind`:
+#   - `resource`: the resource of kind "managed"
+#   - `data`: the data resource of kind "data"
 # scope: rule
 resources contains resource if {
 	[_, value] := walk(tfstate)

--- a/rego/lib/tfstate_test/resources_test.rego
+++ b/rego/lib/tfstate_test/resources_test.rego
@@ -9,5 +9,18 @@ test_resources_count_empty if {
 }
 
 test_resources_count_real_tfstate if {
-	count(tfstate.resources) == 70 with input as data.lib.tfstate_test.testdata["eks-attach-policy-to-nodes"]
+	resources := tfstate.resources with input as data.lib.tfstate_test.testdata["eks-attach-policy-to-nodes"]
+	count(resources) == 70
+
+	# Check actual Terraform resources, i.e. the `resource` one that are
+	# also showed via `plan` and `apply` output.
+	managed_resources := [resource | some resource in resources; resource.mode == "managed"]
+	count(managed_resources) == 58
+
+	# Check actual Terraform data (resources), i.e. the `data` one that are
+	# not showed via `plan` and `apply` output.
+	data_resources := [resource | some resource in resources; resource.mode == "data"]
+	count(data_resources) == 12
+
+	count(resources) == count(managed_resources) + count(data_resources)
 }


### PR DESCRIPTION
This PR add further checks in order to double-check that 58 Terraform resources (AKA managed resources) are managed by `eks-attach-policy-to-nodes` tfstate and also check the data resources (simply `data` in Terraform).

While here, also explain that in the `resources` rule.
