### PR TITLE
Spell "mode" correctly in comment

### DIFF
--- a/rego/lib/tfstate/resources.rego
+++ b/rego/lib/tfstate/resources.rego
@@ -19,7 +19,7 @@ import input as tfstate
 #  Walk the Terraform state and flatten all Terraform resources.
 #
 #  Please note that the Terraform resources in the state can be Terraform
-#  `resource` or `data` based on their `kind`:
+#  `resource` or `data` based on their `mode`:
 #   - `resource`: the resource of kind "managed"
 #   - `data`: the data resource of kind "data"
 # scope: rule


### PR DESCRIPTION
It is the "mode" field, not "kind" field that define if it is a `resource` or `data`!

For more information please see: <https://opentofu.org/docs/internals/json-format/#values-representation> (also the tests correctly tested that, whoops!)
