### PR TITLE
Add an empty live module

### DIFF
--- a/terraform/empty/main.tf
+++ b/terraform/empty/main.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "~> 1.3"
+}


### PR DESCRIPTION
This should be the shortest Terraform code that is fine both for OpenTofu, Terraform and TFLint.

The corresponding tfstate is just:

```json
{"format_version":"1.0"}
```

Please note that strictly speaking the shortest Terraform code is just a
directory with an empty `main.tf` (or whatever). In that case the
version in the tfstate would be `0.1` instead of `1.0`. I have also
specified the `required_version` so it is valid with TFLint too.
