### PR TITLE
Pin to tflint-v0.50.3

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -30,6 +30,8 @@ jobs:
           tofu_version: 1.8.x
       - name: Setup tflint
         uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: v0.50.3
       - name: Checking Terraform formatting style
         run: |
           cd terraform


### PR DESCRIPTION
tflint v0.50.3 is the latest version with Terraform code not licensed under the BUSL. Pin to it to avoid any possible license issues.
