### PR TITLE
Add `{data,managed}_resources` rules

### DIFF
--- a/rego/.regal/config.yaml
+++ b/rego/.regal/config.yaml
@@ -12,3 +12,8 @@ rules:
     line-length:
       level: error
       non-breakable-word-threshold: 80
+      ignore:
+        files:
+          # Either violate `line-length` (if we format it) or `opa-fmt` if we
+          # split the long line.
+          - "lib/tfstate_test/resources_test.rego"

--- a/rego/lib/tfstate/resources.rego
+++ b/rego/lib/tfstate/resources.rego
@@ -27,3 +27,21 @@ resources contains resource if {
 	[_, value] := walk(tfstate)
 	some resource in value.resources
 }
+
+# METADATA
+# description: |
+#  Return data resources, AKA actual `data` in Terraform.
+# scope: rule
+data_resources contains resource if {
+	some resource in resources
+	resource.mode == "data"
+}
+
+# METADATA
+# description: |
+#  Return managed resources, AKA actual `resource` in Terraform.
+# scope: rule
+managed_resources contains resource if {
+	some resource in resources
+	resource.mode == "managed"
+}

--- a/rego/lib/tfstate_test/resources_test.rego
+++ b/rego/lib/tfstate_test/resources_test.rego
@@ -9,18 +9,29 @@ test_resources_count_empty if {
 }
 
 test_resources_count_real_tfstate if {
+	count(tfstate.resources) == 70 with input as data.lib.tfstate_test.testdata["eks-attach-policy-to-nodes"]
+}
+
+test_data_resources_count_empty if {
+	count(tfstate.data_resources) == 0 with input as {}
+}
+
+test_data_resources_count_real_tfstate if {
+	count(tfstate.data_resources) == 12 with input as data.lib.tfstate_test.testdata["eks-attach-policy-to-nodes"]
+}
+
+test_managed_resources_count_empty if {
+	count(tfstate.managed_resources) == 0 with input as {}
+}
+
+test_managed_resources_count_real_tfstate if {
+	count(tfstate.managed_resources) == 58 with input as data.lib.tfstate_test.testdata["eks-attach-policy-to-nodes"]
+}
+
+test_all_resources_count_real_tfstate if {
 	resources := tfstate.resources with input as data.lib.tfstate_test.testdata["eks-attach-policy-to-nodes"]
-	count(resources) == 70
+	data_resources := tfstate.data_resources with input as data.lib.tfstate_test.testdata["eks-attach-policy-to-nodes"]
+	managed_resources := tfstate.managed_resources with input as data.lib.tfstate_test.testdata["eks-attach-policy-to-nodes"]
 
-	# Check actual Terraform resources, i.e. the `resource` one that are
-	# also showed via `plan` and `apply` output.
-	managed_resources := [resource | some resource in resources; resource.mode == "managed"]
-	count(managed_resources) == 58
-
-	# Check actual Terraform data (resources), i.e. the `data` one that are
-	# not showed via `plan` and `apply` output.
-	data_resources := [resource | some resource in resources; resource.mode == "data"]
-	count(data_resources) == 12
-
-	count(resources) == count(managed_resources) + count(data_resources)
+	count(resources) == count(data_resources) + count(managed_resources)
 }


### PR DESCRIPTION
Write dedicated rules to get "data" resources (AKA "data" in Terraform code) and "managed" resources (AKA "resource" in Terraform code).

Move the part that tests all of them in a dedicated test.
