### PR TITLE
Add initial AWS EKS policies

### DIFF
--- a/rego/policy/aws/eks/main.rego
+++ b/rego/policy/aws/eks/main.rego
@@ -1,0 +1,55 @@
+# METADATA
+# title: AWS EKS policies
+# description: |
+#  Policies for AWS EKS.
+# entrypoint: true
+package policy.aws.eks
+
+import rego.v1
+
+import data.lib.tfstate
+
+# METADATA
+# description: |
+#  EKS node IAM roles assumes that they have the `AmazonEKSWorkerNodePolicy`
+#  IAM AWS managed policy attached.
+node_roles := [role |
+	some policy in tfstate.managed_resources
+	some role in tfstate.managed_resources
+	policy.type == "aws_iam_role_policy_attachment"
+	policy.values.policy_arn == "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+	role.type == "aws_iam_role"
+	policy.values.role == role.values.name
+]
+
+# METADATA
+# title: Deny extra IAM policies to EKS node IAM role
+# description: |
+#  The EKS node IAM role should have only the following IAM policies:
+#   - AmazonEKSWorkerNodePolicy
+#   - AmazonEC2ContainerRegistryPullOnly
+#   - (optional) AmazonEKS_CNI_Policy
+#  Attaching other IAM policies permit all pods to use underlying IAM
+#  actions.
+# related_resources:
+#  - description: Amazon EKS node IAM role
+#    ref: https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html
+#  - description: aws_eks_node_group resource, hashicorp/aws Terraform provider
+#    ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group
+# scope: rule
+deny_extra_policies_in_node_roles contains msg if {
+	some node_role in node_roles
+	some resource in tfstate.managed_resources
+	resource.type == "aws_iam_role_policy_attachment"
+	resource.values.role == node_role.values.name
+	not resource.values.policy_arn in {
+		"arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPullOnly",
+		"arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+		"arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+		"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+	}
+	msg := sprintf(
+		"`aws_iam_role` `%v` is a node role and should not have `aws_iam_role_policy_attachment` `%v` attached to it",
+		[node_role.values.name, resource.values.policy_arn],
+	)
+}

--- a/rego/policy/aws/eks_test/main_test.rego
+++ b/rego/policy/aws/eks_test/main_test.rego
@@ -1,0 +1,48 @@
+package policy.aws.eks_test
+
+import rego.v1
+
+import data.policy.aws.eks
+
+test_deny_extra_policies_in_node_roles_match if {
+	resources := [
+		{
+			"type": "aws_iam_role_policy_attachment",
+			"values": {
+				"role": "fake_role",
+				"policy_arn": "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+			},
+		},
+		{
+			"type": "aws_iam_role_policy_attachment",
+			"values": {
+				"role": "fake_role",
+				"policy_arn": "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+			},
+		},
+		{
+			"type": "aws_iam_role",
+			"values": {"name": "fake_role"},
+		},
+	]
+
+	eks.deny_extra_policies_in_node_roles with data.lib.tfstate.managed_resources as resources
+}
+
+test_deny_extra_policies_in_node_roles_mismatch if {
+	resources := [
+		{
+			"type": "aws_iam_role_policy_attachment",
+			"values": {
+				"role": "fake_role",
+				"policy_arn": "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+			},
+		},
+		{
+			"type": "aws_iam_role",
+			"values": {"name": "fake_role"},
+		},
+	]
+
+	count(eks.deny_extra_policies_in_node_roles) == 0 with data.lib.tfstate.managed_resources as resources
+}


### PR DESCRIPTION
Add a rule to find EKS node IAM role and a policy to deny possible extra AWS IAM policies attached then the ones that are strictly needed.
