### PR TITLE
Run CI at least once weekly

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -5,6 +5,8 @@ name: Check GitHub Actions workflows
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: '18 3 * * 3'
 
 jobs:
   actionlint:

--- a/.github/workflows/mdformat.yaml
+++ b/.github/workflows/mdformat.yaml
@@ -5,6 +5,8 @@ name: Check Markdown formatting via mdformat
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: '18 3 * * 3'
 
 jobs:
   mdformat:

--- a/.github/workflows/rego.yaml
+++ b/.github/workflows/rego.yaml
@@ -5,6 +5,8 @@ name: Check and validate Rego code
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: '18 3 * * 3'
 
 jobs:
   terraform:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -5,6 +5,8 @@ name: Check and validate Terraform live modules
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: '18 3 * * 3'
 
 jobs:
   terraform:


### PR DESCRIPTION
According "Continuous integration" capability by DevOps Research and Assessment (DORA), quoting relevant part:

> You should run your build process successfully at least once a day.

From <https://dora.dev/capabilities/continuous-integration/>

Once a day for personal projects is probably too much so let limit ourselves to once a week for environmental reasons.

Time and day of the week are mostly random outside working hours in US/EU.
