### PR TITLE
Ignore data files for unresolved-reference

### DIFF
--- a/rego/.regal/config.yaml
+++ b/rego/.regal/config.yaml
@@ -8,6 +8,10 @@ rules:
   idiomatic:
     directory-package-mismatch:
       exclude-test-suffix: false
+  imports:
+    unresolved-reference:
+      except-paths:
+        - data.lib.tfstate_test.testdata
   style:
     line-length:
       level: error


### PR DESCRIPTION
Add an exception for the unresolved-reference rule. `data.lib.tfstate_test.testdata` contains only data and should be ignored by unresolved-reference.
