### PR TITLE
Revoke all unneeded permissions to GitHub Actions

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,4 +1,5 @@
 name: Check GitHub Actions workflows
+permissions: {}
 
 'on':
   push:

--- a/.github/workflows/mdformat.yaml
+++ b/.github/workflows/mdformat.yaml
@@ -1,4 +1,5 @@
 name: Check Markdown formatting via mdformat
+permissions: {}
 
 'on':
   push:

--- a/.github/workflows/rego.yaml
+++ b/.github/workflows/rego.yaml
@@ -1,4 +1,5 @@
 name: Check and validate Rego code
+permissions: {}
 
 'on':
   push:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,4 +1,5 @@
 name: Check and validate Terraform live modules
+permissions: {}
 
 'on':
   push:


### PR DESCRIPTION
Only "metadata" read permissions are actually needed and these are given by default also with `permissions: {}`.

`actions/checkout` says that `permissions.contents: read` is needed. However, for our use cases no contents operations are actually needed.

---

The permissions can be seen under each GitHub Actions workflow logs, under "Set up job", there is something like the following:

> GITHUB_TOKEN Permissions
>  Contents: read
>  Metadata: read
>  Packages: read

...or something:

> GITHUB_TOKEN Permissions
>   Actions: write
>   ArtifactMetadata: write
>   Attestations: write
>   Checks: write
>   Contents: write
>   Deployments: write
>   Discussions: write
>   Issues: write
>   Metadata: read
>   Models: read
>   Packages: write
>   Pages: write
>   PullRequests: write
>   RepositoryProjects: write
>   SecurityEvents: write
>   Statuses: write

And yeah, all these write-s are much more dangerous in case `GITHUB_TOKEN` gets leaked!

---

Please see <https://github.com/iamleot/rpi-flux/pull/190> for corresponding experiments too.
